### PR TITLE
Restore main for ESLint compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tinyld",
   "description": "Simple and Performant Language detection library (pure JS and zero dependencies)",
   "version": "1.3.0",
+  "main": "./dist/tinyld.normal.node.js",
   "exports": {
     ".": {
       "require": "./dist/tinyld.normal.node.js",


### PR DESCRIPTION
Unfortunately, the `import/no-unresolved` ESLint rule doesn't yet work without a `main` property (https://github.com/import-js/eslint-plugin-import/issues/2132). While this package works without it, would you be willing to restore it (until it's fixed) to avoid having to disable the ESLint rule? (Similar to https://github.com/vitejs/vite/pull/8296.)